### PR TITLE
pull out channel data needed for heuristic blocker

### DIFF
--- a/lib/heuristicBlocker.js
+++ b/lib/heuristicBlocker.js
@@ -1,0 +1,80 @@
+"use strict";
+
+const { Cc, Ci } = require("chrome");
+const { newURI } = require('sdk/url/utils');
+const utils = require("utils.js");
+
+/*
+ * Determine if a request should not be considered in the blocker accounting
+ * (e.g. it is an internal protocol)
+ */
+let ignoreRequest = function(request) {
+  // TODO: decide what to ignore here (about://, chrome://, etc.)
+  return false;
+}
+
+/*
+ * Returns useful information about this channel.
+ *
+ * {
+ *   domain: "",       // The domain (eTLD+1) of this request
+ *   party: "",        // first|third (in the context of its parents in the
+ *                        window hierarchy)
+ *   parentDomain: "", // If this domain is third-party, the domain of the
+ *                        parent's (first party) domain
+ * }
+ *
+ * Returns null if the channel could not be introspected. This can happen for
+ * requests that are not associated with a window (e.g. OCSP, Safe Browsing).
+ */
+let getChannelInfo = function(channel) {
+  let win = utils.getTopWindowForChannel(channel);
+  // Ignore requests that are outside a tabbed window
+  if (win == null) return null;
+
+  let info = {};
+  info.domain = utils.getBaseDomain(channel.URI);
+
+  try {
+    if (utils.isThirdPartyChannel(channel)) {
+      info.party = "third";
+    } else {
+      info.party = "first";
+    }
+  } catch (e) {
+    // If this logic failed, we can't determine the party of the request
+    console.log("isThirdPartyChannel threw exception for " + channel.URI.spec);
+    return null;
+  }
+
+  if (info.party === "third") {
+    try {
+      // use win.document.URL, instead of win.location, because win.location
+      // can be modified by scripts.
+      info.parentDomain = utils.getBaseDomain(newURI(win.document.URL));
+    } catch (e) {
+      console.log("error getting base domain from third party request " + channel.URI.spec);
+      return null;
+    }
+  }
+
+  return info;
+}
+
+/*
+ * Update internal accounting data structures with this request.
+ * Returns true if we updated the blocker's data structures.
+ */
+let updateHeuristics = function(channel) {
+  if (ignoreRequest(channel)) return false;
+
+  let channelInfo = getChannelInfo(channel);
+  if (channelInfo == null) {
+    // for whatever reason, we couldn't introspect this channel. Check the console.
+    return false;
+  }
+  console.log(channelInfo);
+  return true;
+}
+
+exports.updateHeuristics = updateHeuristics;

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,15 +5,16 @@
 "use strict";
 
 const { Cc, Ci } = require("chrome");
-let pbContentPolicy = require("pbContentPolicy");
-let pbUI = require("ui.js");
-let events = require("sdk/system/events");
+const pbContentPolicy = require("pbContentPolicy");
+const pbUI = require("ui.js");
+const events = require("sdk/system/events");
+const heuristicBlocker = require("heuristicBlocker.js");
 
 // http-on-examine-response
 // https://addons.mozilla.org/en-US/developers/docs/sdk/1.13/modules/sdk/system/events.html
 function onExamineResponse(event) {
   let channel = event.subject.QueryInterface(Ci.nsIHttpChannel);
-  console.log("Got http-on-examine-response event");
+  heuristicBlocker.updateHeuristics(channel);
 }
 
 function main(options) {

--- a/lib/pbContentPolicy.js
+++ b/lib/pbContentPolicy.js
@@ -21,7 +21,7 @@ exports.pbContentPolicy = Class({
   shouldLoad: function(aContentType, aContentLocation, aRequestOrigin,
                        aContext, aMimeType, aExtra) {
     // NOP (just setting up the machinery)
-    console.log("in shouldLoad, loading " + aContentLocation.spec);
+    //console.log("in shouldLoad, loading " + aContentLocation.spec);
     return Ci.nsIContentPolicy.ACCEPT;
   },
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,59 @@
+"use strict";
+
+const { Cc, Ci, Cu, Cr } = require("chrome");
+const ThirdPartyUtil = Cc["@mozilla.org/thirdpartyutil;1"]
+                       .getService(Ci.mozIThirdPartyUtil);
+
+
+/*
+ * Tries to get the window associated with a channel. If it cannot, returns
+ * null and logs an explanation to the console. This is not necessarily an
+ * error, as many internal requests are not associated with a window, e.g. OCSP
+ * or Safe Browsing requests.
+ */
+let getWindowForChannel = function(channel) {
+  // Obtain an nsIDOMWindow from a channel
+  let nc;
+  try {
+    nc = channel.notificationCallbacks ? channel.notificationCallbacks : channel.loadGroup.notificationCallbacks;
+  } catch(e) {
+    console.log("no loadgroup notificationCallbacks for " + channel.URI.spec);
+    return null;
+  }
+
+  if (!nc) {
+    console.log("no window for " + channel.URI.spec);
+    return null;
+  }
+
+  let domWin;
+  try {
+    domWin = nc.getInterface(Ci.nsIDOMWindow);
+  } catch(e) {
+    console.log("No window associated with request: " + channel.URI.spec);
+    return null;
+  }
+
+  if (!domWin) {
+    console.log("failed to get DOMWin for " + channel.URI.spec);
+    return null;
+  }
+
+  return domWin;
+};
+
+/*
+ * Returns the top window in the given channel's associated window hierarchy.
+ */
+let getTopWindowForChannel = function(channel) {
+  let win = getWindowForChannel(channel);
+  if (win) {
+    return win.top;
+  }
+  return null;
+};
+
+exports.getBaseDomain = ThirdPartyUtil.getBaseDomain;
+exports.isThirdPartyChannel = ThirdPartyUtil.isThirdPartyChannel;
+
+exports.getTopWindowForChannel = getTopWindowForChannel;


### PR DESCRIPTION
Examines channel requests and provides basic metadata so we can build the data structures necessary for the heuristic blocker.
