### PR TITLE
Update heuristics

### DIFF
--- a/lib/heuristicBlocker.js
+++ b/lib/heuristicBlocker.js
@@ -118,6 +118,12 @@ let getChannelInfo = function(channel) {
   return info;
 }
 
+/**
+ * Parse a cookie header (Set-Cookie or Cookie) into (key, value) pairs and
+ * returns the parsed cookies in an object.
+ * @param {string} header The contents of the header
+ * @return {Object} map of cookie keys to values
+ */
 let parseCookieHeader = function(header) {
   let cookies = {};
 


### PR DESCRIPTION
Two thoughts:
1. in updateHeuristics, repeatedly referencing the properties on channelInfo hampers readability. It might be good to expand the needed properties, e.g.

```
let channelInfo = getChannelInfo(channel);
// Expand properties for readability
let { origin, party, parentOrigin } = channelInfo;
```

I checked, that syntax is valid when you return an object from a function (that's how `require` works).
1. It might make more sense to do the cookie parsing in getChannelInfo, along with the rest of it.
