### PR TITLE
Set DNT via the prefs service

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -26,19 +26,10 @@ const prefs = require('sdk/simple-prefs').prefs;
 
 /**
  *  http-on-modify-request:
- *    sets DNT on all requests, updates heuristics, emits events to the
- *    panel.
- *
- *  Note that userRed and other blocked requests are handled by ContentPolicy.
- *  userYellow cookie clobbering is also handled separately. There's no need
- *  to re-clobber cookies on every request.
- *
+ *    updates heuristics, checks if cookieblock is needed, strips referers
  */
 function onModifyRequest(event) {
   let channel = event.subject.QueryInterface(Ci.nsIHttpChannel);
-
-  // Always set DNT?
-  channel.setRequestHeader("DNT", "1", false);
 
   if (ignoreRequest(channel)) { return; }
 
@@ -142,7 +133,7 @@ let ignoreRequest = function(channel) {
 };
 
 /*
- * Enable Privacy Badger from the PB panel. Not currently used.
+ * Enable Privacy Badger from the PB panel. Not currently used by itself.
  */
 function enable() {
   prefsListener.init();
@@ -167,7 +158,7 @@ function enable() {
  * Disable Privacy Badger from the PB panel. This differs from disabling
  * Privacy Badger from about:addons because the addon button remains in the
  * toolbar, so PB can be easily re-enabled from its own panel. Not currently
- * used.
+ * used by itself.
  */
 function disable() {
   prefsListener.cleanup();

--- a/lib/prefsListener.js
+++ b/lib/prefsListener.js
@@ -28,6 +28,12 @@ const events = require("sdk/system/events");
  *     * 1 = ask every time
  *     * 2 = until I close Firefox
  *     * 3 = cookie lasts for number of days specified by network.cookie.lifetime.days
+ *  * privacy.donottrackheader.enabled
+ *    * true = set dnt header
+ *    * false = don't set dnt header (default)
+ *  * privacy.donottrackheader.value
+ *    * 1 = standard value (default)
+ *    * otherwise, see https://bugzilla.mozilla.org/show_bug.cgi?id=765398#c24
  *
  */
 
@@ -35,6 +41,9 @@ const cookiePrefsBranch = "network.cookie.";
 const cookiePrefsTarget = PrefsTarget({ branchName: cookiePrefsBranch });
 const cookieBehaviorPref = "cookieBehavior";
 const cookieLifetimePref = "lifetimePolicy";
+
+const dntEnabledPref = "privacy.donottrackheader.enabled";
+const dntValuePref = "privacy.donottrackheader.value";
 
 let prefBlocksCookies;
 let prefDeletesCookies;
@@ -72,6 +81,36 @@ let checkCookiePrefs = function(prefName) {
   }
 };
 
+let checkDntPrefs = function(prefName) {
+  let pref = prefsService.get(prefName);
+  switch(prefName) {
+    case dntEnabledPref:
+      // remember the original pref
+      prefs.prefs.doNotTrackDefaultEnabled = pref;
+      prefsService.set(dntEnabledPref, true);
+      break;
+    case dntValuePref:
+      prefs.prefs.doNotTrackDefaultValue = pref;
+      prefsService.set(dntValuePref, 1);
+      break;
+  }
+};
+
+let resetDntPrefs = function(prefName) {
+  let pref = prefsService.get(prefName);
+  let oldPref;
+  switch(prefName) {
+    case dntEnabledPref:
+      oldPref = prefs.prefs.doNotTrackDefaultEnabled;
+      prefsService.set(dntEnabledPref, oldPref);
+      break;
+    case dntValuePref:
+      oldPref = prefs.prefs.doNotTrackDefaultValue;
+      prefsService.set(dntValuePref, oldPref);
+      break;
+  }
+};
+
 function initCookiePrefListener() {
   // Register listener for pref changes on startup.
   //
@@ -82,12 +121,16 @@ function initCookiePrefListener() {
   // Do initial check for the relevant pref values at startup
   checkCookiePrefs(cookieBehaviorPref);
   checkCookiePrefs(cookieLifetimePref);
+  checkDntPrefs(dntEnabledPref);
+  checkDntPrefs(dntValuePref);
 }
 
 function cleanupCookiePrefListener() {
   off(cookiePrefsTarget, "", checkCookiePrefs);
   events.off("http-on-examine-response", main.onExamineResponse, false);
   events.off("quit-application-granted", main.onQuitApplicationGranted, false);
+  resetDntPrefs(dntEnabledPref);
+  resetDntPrefs(dntValuePref);
 }
 
 /*

--- a/package.json
+++ b/package.json
@@ -13,6 +13,18 @@
     "title": "Automatic blocking enabled",
     "type": "bool",
     "value": true
+  }, {
+    "name": "doNotTrackDefaultEnabled",
+    "title": "Default value of privacy.donottrackheader.enabled",
+    "type": "bool",
+    "value": false,
+    "hidden": true
+  }, {
+    "name": "doNotTrackDefaultValue",
+    "title": "Default value of privacy.donottrackheader.value",
+    "type": "integer",
+    "value": 1,
+    "hidden": true
   }],
   "icon": "data/icons/badger-48.png",
   "icon64": "data/icons/badger-64.png"


### PR DESCRIPTION
Closes #91 

This intentionally doesn't set the DNT header if users manually unset it in `about:preferences` after installing Privacy Badger, until Privacy Bader is restarted. This makes it less frustrating for superusers who want to use Privacy Badger but not send DNT for some reason.
