### PR TITLE
Fixed race condition in content script

### DIFF
--- a/data/socialwidgets.js
+++ b/data/socialwidgets.js
@@ -47,50 +47,39 @@ let CONTENT_SCRIPT_STYLESHEET_PATH = "skin/socialwidgets.css";
 let contentScriptFolderUrl;
 
 /**
- * Keep track of buttons to replace, to avoid duplicate work on re-check
+ * Social widget tracker data, read from file.
  */
-let savedTrackerButtonsToReplace = {};
-let firstTime = true;
+let trackerInfo;
 
 /**
  * Initializes the content script.
  */
 function initialize() {
-  let head = document.querySelector("head");
-  if (head === null) {
-    return; // not really html page, don't bother
-  }
+  // set up listener for blocks that happen after initial check
+  self.port.on("replaceSocialWidget", function(trackerDomain) {
+    replaceSubsequentTrackerButtonsHelper(trackerDomain);
+  });
 
-  realInitialize();
-}
-
-function realInitialize() {
+  // get tracker info and check for initial blocks (that happened
+  // before content script was attached)
   getTrackerData(function(contentScriptFolderUrl2, trackers,
                           trackerButtonsToReplace,
                           socialWidgetReplacementEnabled) {
 
     if (!socialWidgetReplacementEnabled) { return; }
 
-    if (firstTime) {
-      contentScriptFolderUrl = contentScriptFolderUrl2;
+    contentScriptFolderUrl = contentScriptFolderUrl2;
+    trackerInfo = trackers;
 
-      // add the Content.css stylesheet to the page
-      let head = document.querySelector("head");
-      let stylesheetLinkElement = getStylesheetLinkElement(contentScriptFolderUrl +
-                                                           CONTENT_SCRIPT_STYLESHEET_PATH);
-      if (head != null) {
-        head.appendChild(stylesheetLinkElement);
-      }
-      firstTime = false;
-
-      // Sometimes there's a race condition where the extension doesn't yet know if
-      // something has been blocked. Try again after some time so we don't end up
-      // with blocked but un-replaced buttons...
-      setTimeout(realInitialize, 1000);
+    // add the Content.css stylesheet to the page
+    let head = document.querySelector("head");
+    let stylesheetLinkElement = getStylesheetLinkElement(contentScriptFolderUrl +
+                                                         CONTENT_SCRIPT_STYLESHEET_PATH);
+    if (head != null) {
+      head.appendChild(stylesheetLinkElement);
     }
 
-    replaceTrackerButtonsHelper(trackers, trackerButtonsToReplace);
-    savedTrackerButtonsToReplace = trackerButtonsToReplace;
+    replaceInitialTrackerButtonsHelper(trackerButtonsToReplace);
   });
 }
 
@@ -258,35 +247,50 @@ function replaceScriptsRecurse(node) {
  * Replaces all tracker buttons on the current web page with the internal
  * replacement buttons, respecting the user's blocking settings.
  *
- * @param {Array} trackers an array of Tracker objects
  * @param {Object} a map of Tracker names to Boolean values saying whether
  *                 those trackers' buttons should be replaced
  */
-function replaceTrackerButtonsHelper(trackers, trackerButtonsToReplace) {
-  trackers.forEach(function(tracker) {
+function replaceInitialTrackerButtonsHelper(trackerButtonsToReplace) {
+  trackerInfo.forEach(function(tracker) {
     let replaceTrackerButtons = trackerButtonsToReplace[tracker.name];
-    let savedReplaceTrackerButtons = savedTrackerButtonsToReplace[tracker.name];
-    let statusChanged = (replaceTrackerButtons != savedReplaceTrackerButtons);
-
-    if (replaceTrackerButtons && statusChanged) {
-      console.log("replacing tracker button for " + tracker.name);
-
-      // makes a comma separated list of CSS selectors that specify
-      // buttons for the current tracker; used for document.querySelectorAll
-      let buttonSelectorsString = tracker.buttonSelectors.toString();
-      let buttonsToReplace =
-        document.querySelectorAll(buttonSelectorsString);
-
-      for (let i = 0; i < buttonsToReplace.length; i++) {
-        let buttonToReplace = buttonsToReplace[i];
-
-        let button =
-          createReplacementButtonImage(tracker);
-
-        buttonToReplace.parentNode.replaceChild(button, buttonToReplace);
-      }
+    if (replaceTrackerButtons) {
+      replaceIndividualButton(tracker);
     }
   });
+}
+
+/**
+ * Individually replaces tracker buttons blocked after initial check.
+ */
+function replaceSubsequentTrackerButtonsHelper(trackerDomain) {
+  trackerInfo.forEach(function(tracker) {
+    let replaceTrackerButtons = (tracker.domain == trackerDomain);
+    if (replaceTrackerButtons) {
+      replaceIndividualButton(tracker);
+    }
+  });
+}
+
+/**
+ * Actually do the work of replacing the button.
+ */
+function replaceIndividualButton(tracker) {
+  console.log("replacing tracker button for " + tracker.name);
+
+  // makes a comma separated list of CSS selectors that specify
+  // buttons for the current tracker; used for document.querySelectorAll
+  let buttonSelectorsString = tracker.buttonSelectors.toString();
+  let buttonsToReplace =
+    document.querySelectorAll(buttonSelectorsString);
+
+  for (let i = 0; i < buttonsToReplace.length; i++) {
+   let buttonToReplace = buttonsToReplace[i];
+
+    let button =
+      createReplacementButtonImage(tracker);
+
+    buttonToReplace.parentNode.replaceChild(button, buttonToReplace);
+  }
 }
 
 /**

--- a/lib/main.js
+++ b/lib/main.js
@@ -193,7 +193,20 @@ function enable() {
         contentScriptFile: data.url("socialwidgets.js")
       });
 
-      // Respond to content script's query about which trackers should be blocked
+      // Store the worker so we can send messages to it from elsewhere
+      pbUI.tabWorkers.set(utils.getWindowForSdkTab(tab), worker);
+
+      // Don't keep non-active workers
+      worker.on('pageshow', function() { pbUI.tabWorkers.set(utils.getWindowForSdkTab(tab), worker); });
+      worker.on('pagehide', function() {
+        let aWin = utils.getWindowForSdkTab(tab);
+	if (aWin != null) {
+          pbUI.tabWorkers.delete(aWin);
+        }
+      });
+
+      // Respond to content script's query about which trackers have already been
+      // blocked before the content script was attached
       worker.port.on("socialWidgetContentScriptReady", function(aWin) {
         let socialWidgetContentScriptData =
           socialWidgetHandler.getSocialWidgetContentScriptData(tab);
@@ -207,6 +220,7 @@ function enable() {
         socialWidgetHandler.unblockSocialWidgetOnTab(tab, socialWidgetUrls);
         worker.port.emit("unblockSocialWidget_Response");
       });
+
     });
   }
 }

--- a/lib/socialWidgetHandler.js
+++ b/lib/socialWidgetHandler.js
@@ -36,7 +36,6 @@
 const { data } = require("sdk/self");
 const socialWidgetLoader = require("./socialWidgetLoader");
 const { settingsMap, tempUnblockMap } = require("./ui");
-const tabUtils = require("sdk/tabs/utils");
 const utils = require("./utils");
 
 let socialWidgetList;
@@ -59,7 +58,7 @@ exports.getSocialWidgetContentScriptData = function(tab) {
     let socialWidgetName = socialWidget.name;
 
     // replace them if PrivacyBadger has blocked them
-    let aWin = getWindow(tab);
+    let aWin = utils.getWindowForSdkTab(tab);
     let blockedData = settingsMap.get(aWin);
 
     if (blockedData && blockedData[socialWidget.domain]) {
@@ -84,7 +83,7 @@ exports.getSocialWidgetContentScriptData = function(tab) {
 exports.unblockSocialWidgetOnTab = function(tab, socialWidgetUrls) {
   for (let socialWidgetUrl of socialWidgetUrls) {
     let socialWidgetHost = utils.getHostname(socialWidgetUrl);
-    let aWin = getWindow(tab);
+    let aWin = utils.getWindowForSdkTab(tab);
     //console.log("UNBLOCKING FOR THIS WINDOW ONLY: "
     //              + socialWidgetHost + " " + aWin.location);
     let tempUnblock = tempUnblockMap.get(aWin, {});
@@ -102,16 +101,6 @@ exports.isSocialWidgetTemporaryUnblock = function(aLoc, aWin) {
     return true;
   }
 };
-
-// Given a high-level tab, turn into low-level xul tab object to get window
-function getWindow(sdkTab) {
-  for (let tab of tabUtils.getTabs()) {
-    if (sdkTab.id === tabUtils.getTabId(tab)) {
-      return tabUtils.getTabContentWindow(tab);
-    }
-  }
-  return null;
-}
 
 exports.clearTemporaryUnblocksByWin = function(aWin) {
   tempUnblockMap.delete(aWin);

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -225,6 +225,12 @@ let settingsMap = new WeakMap();
 let tempUnblockMap = new WeakMap();
 
 /**
+ * tabWorkers keeps track of the workers for open tabs, so we can send messages
+ * to their content scripts when blockiing happens.
+ */
+let tabWorkers = new WeakMap();
+
+/**
  * Register our event listener to update Settings. Events are emitted
  * in the form emit(target, type, msg, nsIDOMWindow, origin),
  * where origin is the cookie origin and nsIDOMWindow is the parent origin.
@@ -260,6 +266,21 @@ function updateSettingsListener(msg, aWin, aOrigin) {
 
   settingsMap.set(aWin, setting);
   //console.log("settingsMap: ", aWin.location.href, JSON.stringify(settingsMap.get(aWin)));
+
+  notifyContentScript(msg, aWin, aOrigin);
+}
+
+/**
+ * Notify the tab's content script so that it can replace social widgets,
+ * if applicable.
+ */
+function notifyContentScript(msg, aWin, aOrigin) {
+  if (msg == "block" || msg == "userblock") {
+    let tabWorker = tabWorkers.get(aWin);
+    if (tabWorker != null && tabWorker.tab != null) {
+      tabWorker.port.emit("replaceSocialWidget", aOrigin);
+    }
+  }
 }
 
 /**
@@ -275,3 +296,4 @@ exports.clearSettingsMap = function(aWin) {
 
 exports.settingsMap = settingsMap;
 exports.tempUnblockMap = tempUnblockMap;
+exports.tabWorkers = tabWorkers;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -98,6 +98,18 @@ function reloadCurrentTab() {
 }
 
 /**
+ * Given a high-level tab, turn into low-level xul tab object to get window.
+ */
+function getWindowForSdkTab(sdkTab) {
+  for (let tab of tabUtils.getTabs()) {
+    if (sdkTab.id === tabUtils.getTabId(tab)) {
+      return tabUtils.getTabContentWindow(tab);
+    }
+  }
+  return null;
+}
+
+/**
  * Extracts the hostname from a URL (might return null).
  */
 function getHostname(url)
@@ -231,3 +243,4 @@ exports.getHostname = getHostname;
 exports.getWindowForContext = getWindowForContext;
 exports.reloadCurrentTab = reloadCurrentTab;
 exports.getAllWindows = getAllWindows;
+exports.getWindowForSdkTab = getWindowForSdkTab;


### PR DESCRIPTION
The content script checks twice for which trackers are blocked, since the extension might not yet know about all blocked trackers on the first check (but we want the first check to happen as quickly as possible). These two checks sometimes interleave and cause an error (#162). So don't do the second check until the first has completed.
