### PR TITLE
Avoid redeclaring variables

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -59,7 +59,7 @@ function onModifyRequest(event) {
   }
 
   // Update the heuristic blocker
-  let isResponse = false;  // we're looking at a request
+  isResponse = false;  // we're looking at a request
   if (isHeuristicEnabled()) {
     heuristicBlocker.updateHeuristicsForChannel(channel, aWin, isResponse);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -203,7 +203,7 @@ exports.getParentDomain = function(uri) {
  * @return {Boolean}
  */
 exports.checkEachParentDomainString = function(uri, stringCallback, ignoreSelf) {
-  let ignoreSelf = ignoreSelf || false;
+  var ignoreSelf = ignoreSelf || false;
   let suffix = eTLDService.getPublicSuffix(uri);
   let suffixLength = suffix.split('.').length;
   let hostArray = uri.host.split('.');


### PR DESCRIPTION
Fixes #218. Firefox Nighlty (35) is strict about this. PB can now run on Nightly.
