### PR TITLE
Fix stripping of cookies from request

### DIFF
--- a/lib/policyCheck.js
+++ b/lib/policyCheck.js
@@ -149,7 +149,8 @@ function checkPrivacyPolicy(host, callback) {
                       " returned with status " + status);
         callback(success);
       }
-    }
+    },
+    anonymous: true
   }).get();
 }
 


### PR DESCRIPTION
I accidentally added it to the eff.org JSON request, which didn't hurt. Now it should actually strip cookies. Sorry.
