### PR TITLE
Suggestion: Change badge background colors

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -225,9 +225,9 @@ function updateCountForChannel(channel, aWin) {
     }
   }
   var badgeText = numBlocked + "";
-  var badgeColor = "#FF0000";
+  var badgeColor = "#FF3636";
   if(numBlocked == 0){
-    badgeColor = "#00FF00";
+    badgeColor = "#77DD77";
   }
   if(xulapp.satisfiesVersion(">=36") && tab) {
     // Note that you must set both properties simultaneously, otherwise


### PR DESCRIPTION
This is totally personal opinion but I think the current red/green colors on the toolbar button badge are a bit too angry-seeming. See the screenshot below for (both of) the colors in the changed version (ignoring the fact that toolbar button badges generally look crappy on the Linux version of Firefox):

![privacybadgercolors](https://cloud.githubusercontent.com/assets/6169306/9289815/1c84d484-437c-11e5-85cc-fd7e116d4a9e.png)
