### PR TITLE
It's better to say 'bogue' in French

### DIFF
--- a/locale/fr.properties
+++ b/locale/fr.properties
@@ -1,6 +1,6 @@
 activate_on_site = Cliquer pour activer Privacy Badger sur ce site.
 click_badger_activate_on_site = Cliquer l'icone du badge pour activer Privacy Badger sur ce site.
-cookie_prefs_warning = <p id="cookiePrefsWarning">Attention : Privacy Badger Alpha peut ne pas fonctionner correctement avec <a href="https://support.mozilla.org/en-US/kb/enable-and-disable-cookies-website-preferences" target="_blank">votre configuration concernant les cookies de tiers</a>. Il est possible de rencontrer des bugs, que vous pouvez reporter <a href="https://github.com/EFForg/privacybadgerfirefox/issues/" target="_blank">ici</a>. Merci pour votre aide !</p>
+cookie_prefs_warning = <p id="cookiePrefsWarning">Attention : Privacy Badger Alpha peut ne pas fonctionner correctement avec <a href="https://support.mozilla.org/en-US/kb/enable-and-disable-cookies-website-preferences" target="_blank">votre configuration concernant les cookies de tiers</a>. Il est possible de rencontrer des bogues, que vous pouvez reporter <a href="https://github.com/EFForg/privacybadgerfirefox/issues/" target="_blank">ici</a>. Merci pour votre aide !</p>
 deactivate_on_site = Cliquer pour désactiver Privacy Badger sur ce site.
 pb_detected = Privacy Badger a détecté
 pb_has_detected = Jusqu'ici, Privacy Badger a détecté
@@ -13,14 +13,14 @@ loading = Chargement...
 notracking = Les noms de domaine suivants ne semblent pas vous traquer.
 potential = potentiel
 privacy_badger = Privacy Badger
-report_bug = Reporter un bug . . .
+report_bogue = Reporter un bogue . . .
 report_text = Merci de signaler votre erreur ici
 report_terms = Ce rapport d'erreur va transmettre des informations à EFF concernant la version de votre navigateur, le site web actuellement visité et l'état des curseurs de Privacy Badger sur ce site
 report_cancel = Annuler
 report_field = Quel semble être le problème ?
 restore_button = Cela va repositionner <b>tous</b> les traqueurs à leur état initial (vert si vous autorisez les cookies de tiers, par défaut sur Firefox, et jaune dans les autres cas). Etes vous certain(e) de vouloir continuer ?
 settings_disable = Désactiver sur la page courante
-settings_report  = Reporter un bug . . .
+settings_report  = Reporter un bogue . . .
 settings_unblock = Débloquer tous les traqueurs . . .
 status_none_detected = Aucun cookie traqueur détecté.
 status_reload = Recharger la page pour voir les traqueurs actifs.


### PR DESCRIPTION
It's recommended to use 'bogue' instead of 'bug' in French. See http://www.legifrance.gouv.fr/jopdf/common/jo_pdf.jsp?numJO=0&dateJO=19840219&pageDebut=51740&pageFin=&pageCourante=51741 and https://fr.wiktionary.org/wiki/bogue#fr-nom-4