### PR TITLE
Remove the reset button if it's not required

### DIFF
--- a/data/options.js
+++ b/data/options.js
@@ -244,7 +244,12 @@ function _addOriginHTML(rawOrigin, printable, action) {
   }
   var classText = 'class="' + classes.join(" ") + '"';
 
-  return printable + '<div ' + classText + '" data-origin="' + origin + '" tooltip="' + _badgerStatusTitle(action, origin) + '"><div class="honeybadgerPowered tooltip" tooltip="'+ title + '"></div><div class="origin">' + origin + '</div>' + _addToggleHtml(origin, action) + '<img class="tooltipArrow" src="icons/badger-tb-arrow.png"><div class="tooltipContainer"></div></div>';
+  printable += '<div ' + classText + '" data-origin="' + origin + '" tooltip="' + _badgerStatusTitle(action, origin) + '">';
+  // Only add the reset to default button if it's required
+  if (title !== '') {
+    printable += '<div class="honeybadgerPowered tooltip" tooltip="'+ title + '"></div>';
+  }
+  return printable + '<div class="origin">' + origin + '</div>' + _addToggleHtml(origin, action) + '<img class="tooltipArrow" src="icons/badger-tb-arrow.png"><div class="tooltipContainer"></div></div>';
 }
 function _badgerStatusTitle(action, origin){
   let postfix;

--- a/data/popup.js
+++ b/data/popup.js
@@ -321,7 +321,13 @@ function _addOriginHTML(rawOrigin, action, flag, multiTLD) {
   }
   var classText = 'class="' + classes.join(" ") + '"';
   //TODO do something with the flag here to show off opt-out sites
-  return '<div ' + classText + '" data-origin="' + origin + '" tooltip="' + _badgerStatusTitle(action, origin) + '"><div class="honeybadgerPowered tooltip" tooltip="'+ title + '"></div> <div class="origin">'+ flagText + _trimDomains(origin + multiText,25) + '</div>' + _addToggleHtml(origin, action) + '<img class="tooltipArrow" src="icons/badger-tb-arrow.png"><div class="tooltipContainer"></div></div>';
+
+  var result = '<div ' + classText + '" data-origin="' + origin + '" tooltip="' + _badgerStatusTitle(action, origin) + '">';
+  // Only add the reset to default button if it's required
+  if (title !== '') {
+    result += '<div class="honeybadgerPowered tooltip" tooltip="'+ title + '"></div>';
+  }
+  return result + '<div class="origin">'+ flagText + _trimDomains(origin + multiText,25) + '</div>' + _addToggleHtml(origin, action) + '<img class="tooltipArrow" src="icons/badger-tb-arrow.png"><div class="tooltipContainer"></div></div>';
 }
 function _trim(str, max) {
   if (str.length >= max) {


### PR DESCRIPTION
The reset to default button is removed in the popup
and options if it's not required (if the user didn't
override anything for this origin). Before this commit
a blank popup is appearing if hovering the empty spot
which a) is annoying and b) is decreasing HTML parsing
and DOM performance a bit.