### PR TITLE
Comment the unnecessary log about the localstorage entropy.

### DIFF
--- a/data/supercookie.js
+++ b/data/supercookie.js
@@ -103,8 +103,8 @@ function getScScript() {
         lsItem = localStorage.getItem(lsKey);
         estimatedEntropy += estimateMaxEntropy(lsKey + lsItem);
         if (estimatedEntropy > LOCALSTORAGE_ENTROPY_THRESHOLD){
-          console.log("Found hi-entropy localStorage: ", estimatedEntropy,
-            " bits", document.location.href, lsKey);
+          // console.log("Found hi-entropy localStorage: ", estimatedEntropy,
+            // " bits", document.location.href, lsKey);
           return true;
         }
       }
@@ -143,6 +143,7 @@ document.addEventListener(event_id_super_cookie, function (e) {
   self.port.emit('superCookieReport', e.detail);
 });
 
+// TODO: we should only inject when the extension is not deactivated for the current page
 insertScript(getScScript(), {
   event_id_super_cookie: event_id_super_cookie
 });


### PR DESCRIPTION
This log line seems to [confuse people](https://stackoverflow.com/questions/31953321/firefox-40-what-does-the-found-hi-entropy-localstorage-message-mean) and not very informative. It's already commented in the Chrome version.

Add a TODO note for not injecting supercookie detection script when the PB is deactivated (#728, https://github.com/EFForg/privacybadgerchrome/issues/730)