### PR TITLE
Add domain searching on options page

### DIFF
--- a/data/options.html
+++ b/data/options.html
@@ -153,8 +153,13 @@ button
     <p class=""></p>
     <div id="blockedResourcesContainer">
       <p id="detected"></p>
+      <input id="trackingDomainSearch" type="text" value="" placeholder="Search domains" style="width:100%">
       <div class="spacer"></div>
-      <div id="blockedResources"><span data-l10n-id="options_loading"></span></div>
+      <div id="blockedResources">
+        <div id="blockedOriginsInner">
+          <span data-l10n-id="options_loading"></span>
+        </div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
This fixes #715 by adding a search box to the options page. As user types in search box the list of displayed tracking domains is filtered.

When there is a larger number of tracking domains the first couple keystrokes are a bit delayed until the list of domains is filtered a bit. If you prefer I can update this so no filtering is initiated until a button is clicked.