### PR TITLE
Allow wildcards in domain whitelisting

### DIFF
--- a/lib/userStorage.js
+++ b/lib/userStorage.js
@@ -279,14 +279,39 @@ exports.addToDomainExceptions = function(url, trackingHost, context) {
 };
 
 /**
- * Re-enable privacy badger on a specific site
- * @param {String} url The site to enable
- * @param {Object} context The object that should be used for context - usualy `this`
+ * Re-enable privacy badger on a specific site.
+ * @param {String} hostToEnable The site to enable.
+ * @param {Object} context The object that should be used for context, usually
+                           `this`.
  */
-exports.removeFromDisabledSites = function(host, context) {
-  doDependingOnIsPrivate("disabledSites", function(store) {
-    delete store[host];
-  }, context);
+exports.removeFromDisabledSites = function(hostToEnable, context) {
+  doDependingOnIsPrivate(
+    "disabledSites",
+    function(store) {
+      let baseDomainToEnable = utils.getBaseDomainFromHost(hostToEnable);
+
+      // Check for any whitelisted hosts containing a wildcard.
+      for (let host in store) {
+        // Ignore object properties.
+        if (! store.hasOwnProperty(host)) {
+          continue;
+        }
+
+        // If whitelisted host containing a wildcard is found then
+        // compare the base domain to see if it needs to be removed.
+        if (host.startsWith('*')) {
+          let baseDomain = utils.getBaseDomainFromHost(host);
+          if (baseDomainToEnable === baseDomain) {
+            delete store[host];
+          }
+        }
+      }
+
+      // Remove any exact matches if they exist.
+      delete store[hostToEnable];
+    },
+    context
+  );
 };
 
 /**

--- a/lib/userStorage.js
+++ b/lib/userStorage.js
@@ -251,7 +251,7 @@ exports.empty = function()
     function(store)
     {
       // Don't clear disabledSites or seenComic
-      if (store.indexOf("disabled") !== 0 || 
+      if (store.indexOf("disabled") !== 0 ||
           store.indexOf("seenComic") !== 0) {
         storage[store] = {};
       }
@@ -260,7 +260,7 @@ exports.empty = function()
 };
 exports.addToDisabledSites = function(host, context) {
   doDependingOnIsPrivate("disabledSites", function(store) {
-    store[host] = true; 
+    store[host] = true;
   }, context);
 };
 
@@ -271,7 +271,7 @@ exports.addToDisabledSites = function(host, context) {
  * @param {Object} context The object that should be used for context - usually `this`
  */
 exports.addToDomainExceptions = function(url, trackingHost, context) {
-  let host = utils.makeURI(url).host; 
+  let host = utils.makeURI(url).host;
   doDependingOnIsPrivate("domainExceptions", function(store) {
     if (!store[host]) { store[host] = {}; }
     store[host][trackingHost] = "noaction";
@@ -284,8 +284,8 @@ exports.addToDomainExceptions = function(url, trackingHost, context) {
  * @param {Object} context The object that should be used for context - usualy `this`
  */
 exports.removeFromDisabledSites = function(host, context) {
-  doDependingOnIsPrivate("disabledSites", function(store) { 
-    delete store[host]; 
+  doDependingOnIsPrivate("disabledSites", function(store) {
+    delete store[host];
   }, context);
 };
 
@@ -315,7 +315,7 @@ exports.disabledSitesArray = function(){
  * @param {Object} context The object that should be used for context - usualy `this`
  */
 exports.removeFromDomainExceptions = function(url, trackingHost /*, context*/) {
-  let host = utils.makeURI(url).host; 
+  let host = utils.makeURI(url).host;
   doDependingOnIsPrivate("domainExceptions", function(store) {
     if (!store[host]) { return; }
     delete store[host][trackingHost];
@@ -327,24 +327,56 @@ exports.removeFromDomainExceptions = function(url, trackingHost /*, context*/) {
 };
 
 /**
- * Check if a domain is disabled
- * @param {String} url The site to check
- * @param {Object} context The object that should be used for context - usualy `this`
+ * Determines whether a domain is disabled or not.
+ * @param {String} url The URL to check.
+ * @param {Object} context The object that should be used for context, usually
+ *                         `this`.
+ * @return {Boolean}
  */
 exports.isDisabledSite = function(url, context) {
-  let host;
-  try {
-    host = utils.makeURI(url).host;
-  } catch(e) {
-    // Sometimes URL is null or doesn't have a host
-    return false;
+
+  function isDisabled(uri) {
+    let hostToCheck;
+    let baseDomainToCheck;
+    try {
+      hostToCheck = uri.host;
+      baseDomainToCheck = utils.getBaseDomain(uri);
+    } catch(e) {
+      return false;
+    }
+
+    return doDependingOnIsPrivate(
+      "disabledSites",
+      function(store) {
+        for (let host in store) {
+          // Ignore object properties.
+          if (! store.hasOwnProperty(host)) {
+            continue;
+          }
+
+          // Check for match with whitelisted host containing a wildcard.
+          if (host.startsWith('*')) {
+            let baseDomain = utils.getBaseDomainFromHost(host);
+            if (baseDomainToCheck === baseDomain) {
+              return store[host];
+            }
+          }
+
+          // Check for exact match with whitelisted host.
+          if (hostToCheck === host) {
+            return store[host];
+          }
+        }
+
+        // Site was not found in list of disabled sites so return false.
+        return false;
+      },
+      context
+    );
   }
-  function isDisabled(host) {
-    return doDependingOnIsPrivate("disabledSites", function(store) { 
-      return (store.hasOwnProperty(host)); 
-    }, context);
-  }
-  return (host ? isDisabled(host) : false);
+
+  let uri = utils.makeURI(url);
+  return isDisabled(uri);
 };
 
 /**
@@ -361,8 +393,8 @@ exports.isDomainException = function(url, trackingHost, context) {
     // Sometimes URL is null or doesn't have a host
     return false;
   }
-  if (!host || !trackingHost) { 
-    return false; 
+  if (!host || !trackingHost) {
+    return false;
   }
   // Exception applies if the tracker domain or one of its parents is in the
   // set of exceptions for URL
@@ -381,7 +413,7 @@ exports.isDomainException = function(url, trackingHost, context) {
 
 exports.setSeenComic = function(setting){
   // Hiding this boolean away in an object property so that all storage objects
-  // have a consistent type. 
+  // have a consistent type.
   storage.seenComic.seen = setting;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -295,6 +295,15 @@ exports.isThirdPartyURI = function(uri, docUri) {
 exports.getBaseDomain = ThirdPartyUtil.getBaseDomain;
 
 /**
+ * Determines the base domain of a given host string.
+ * @param {String} host The host to analyze.
+ * @param {Integer} additionalParts The number of domain name parts to return
+ *                                  in addition to the public suffix (optional).
+ * @return {String}
+ */
+exports.getBaseDomainFromHost = eTLDService.getBaseDomainFromHost;
+
+/**
  * getParentDomain - for "www.radio.bbc.co.uk," this would be "radio.bbc.co.uk"
  * for "bbc.co.uk," this would be bbc.co.uk.
  * Not useful right now, but may be for scoping later since a domain

--- a/test/test-user-storage.js
+++ b/test/test-user-storage.js
@@ -2,13 +2,45 @@ const userStorage = require("../lib/userStorage.js");
 userStorage.init();
 
 
+exports.testRemoveFromDisabledSites = function(assert) {
+  let url = "https://www.eff.org"
+  let siteToDisable = "www.eff.org"
+
+  userStorage.addToDisabledSites(siteToDisable, null);
+
+  // Make sure site is enabled after removing from disabled sites.
+  userStorage.removeFromDisabledSites(siteToDisable, null);
+  assert.equal(
+    userStorage.isDisabledSite(url, null), false, url + " should be enabled"
+  )
+};
+
+exports.testRemoveFromDisabledSitesWildcard = function(assert) {
+  let url1 = "https://www.eff.org"
+  let url2 = "https://test.eff.org"
+  let siteToDisable = "*.eff.org"
+  let siteToEnable = "www.eff.org"
+
+  // Add disabled site containing wildcard.
+  userStorage.addToDisabledSites(siteToDisable, null);
+
+  // Make sure disabled site containing wildcard is removed.
+  userStorage.removeFromDisabledSites(siteToEnable, null);
+  assert.equal(
+    userStorage.isDisabledSite(url1, null), false, url1 + " should be enabled"
+  );
+  assert.equal(
+    userStorage.isDisabledSite(url2, null), false, url2 + " should be enabled"
+  );
+};
+
 exports.testIsDisabledSite = function(assert) {
   let url = "https://www.eff.org";
   let disabledSite = "www.eff.org";
 
   // Make sure site is not disabled by default.
   assert.equal(
-    userStorage.isDisabledSite(url, null), false, url + " should not be disabled"
+    userStorage.isDisabledSite(url, null), false, url + " should be enabled"
   );
 
   // Make sure site is disabled after adding to list of disabled sites.

--- a/test/test-user-storage.js
+++ b/test/test-user-storage.js
@@ -1,0 +1,39 @@
+const userStorage = require("../lib/userStorage.js");
+userStorage.init();
+
+
+exports.testIsDisabledSite = function(assert) {
+  let url = "https://www.eff.org";
+  let disabledSite = "www.eff.org";
+
+  // Make sure site is not disabled by default.
+  assert.equal(
+    userStorage.isDisabledSite(url, null), false, url + " should not be disabled"
+  );
+
+  // Make sure site is disabled after adding to list of disabled sites.
+  userStorage.addToDisabledSites(disabledSite, null);
+  assert.equal(
+    userStorage.isDisabledSite(url, null), true, url + " should be disabled"
+  );
+  userStorage.removeFromDisabledSites(disabledSite, null);
+};
+
+exports.testIsDisabledSiteWildcard = function(assert) {
+  let url1 = "https://www.eff.org";
+  let url2 = "https://test.eff.org";
+  let disabledSite = "*.eff.org";
+
+  // Make sure both URLs are disabled after adding wildcard disabled site.
+  userStorage.addToDisabledSites(disabledSite, null);
+  assert.equal(
+    userStorage.isDisabledSite(url1, null), true, url1 + " should be disabled"
+  );
+  assert.equal(
+    userStorage.isDisabledSite(url2, null), true, url2 + " should be disabled"
+  );
+  userStorage.removeFromDisabledSites(disabledSite, null);
+};
+
+
+require("sdk/test").run(exports);


### PR DESCRIPTION
This adds the ability to whitelist domains containing a wildcard from issue #635. When re-enabling a site that's been disabled due to a wildcard whitelisting I opted to have the wildcard whitelisting removed. Let me know if any changes are needed.