### PR TITLE
Refactor domain search on options page

### DIFF
--- a/data/options.js
+++ b/data/options.js
@@ -235,22 +235,34 @@ function showTrackingDomainStats(domains) {
  * @param event Input event triggered by user.
  */
 function filterTrackingDomains(event) {
-  let domains = [];
-  let searchText = $('#trackingDomainSearch').val().toLowerCase();
+  let initialSearchText = $('#trackingDomainSearch').val().toLowerCase();
 
-  for (let trackingDomain in originCache) {
-    // Ignore object properties.
-    if (! originCache.hasOwnProperty(trackingDomain)) {
-      continue;
+  // Wait a short period of time and see if search text has changed.
+  // If so it means user is still typing so hold off on filtering.
+  let timeToWait = 500;
+  setTimeout(function() {
+    // Check search text.
+    let searchText = $('#trackingDomainSearch').val().toLowerCase();
+    if (searchText !== initialSearchText) {
+      return;
     }
 
-    // Ignore domains that do not contain search text.
-    if (trackingDomain.toLowerCase().indexOf(searchText) !== -1) {
-      domains.push(trackingDomain);
-    }
-  }
+    // Filter tracking domains based on search text.
+    let domains = [];
+    for (let trackingDomain in originCache) {
+      // Ignore object properties.
+      if (! originCache.hasOwnProperty(trackingDomain)) {
+        continue;
+      }
 
-  showTrackingDomains(domains);
+      // Ignore domains that do not contain search text.
+      if (trackingDomain.toLowerCase().indexOf(searchText) !== -1) {
+        domains.push(trackingDomain);
+      }
+    }
+
+    showTrackingDomains(domains);
+  }, timeToWait);
 }
 
 /**

--- a/data/options.js
+++ b/data/options.js
@@ -227,7 +227,7 @@ function showTrackingDomainStats(domains) {
   let trackingDomainCount = Object.keys(domains).length;
   $('#count').text(trackingDomainCount);
 
-  showTrackingDomains(domains);
+  showTrackingDomains(Object.keys(domains));
 }
 
 /**
@@ -258,7 +258,7 @@ function filterTrackingDomains(event) {
  * @param domains Tracking domains to display.
  */
 function showTrackingDomains(domains) {
-  let sortedDomains = _reverseSort(Object.keys(domains));
+  let sortedDomains = _reverseSort(domains);
 
   // Create HTML for list of tracking domains.
   let trackerDetails = '<div id="blockedOriginsInner">';


### PR DESCRIPTION
This should hopefully help with the delay while typing in the domain search input on the options page when there are a lot of tracking domains. As the user types it stores the search text, waits half a second, and checks to see if the search text has changed. If so it avoids filtering, otherwise it proceeds.

I also fixed a bug introduced with the page refresh changes.