### PR TITLE
Add-on panel logo open a new tab to main site (Fixes #739)

### DIFF
--- a/data/popup.html
+++ b/data/popup.html
@@ -41,9 +41,6 @@
   <div id='privacy_badger' style="display:none" data-l10n-id="privacy_badger"></div>
   <div id='loading' style="display:none" data-l10n-id="loading"></div>
   <div id='frequently_asked_questions' style="display:none" data-l10n-id="frequently_asked_questions"></div>
-  <div id='deactivate_on_site' style="display:none" data-l10n-id="deactivate_on_site"></div>
-  <div id='activate_on_site' style="display:none" data-l10n-id="activate_on_site"></div>
-  <div id='click_badger_activate_on_site' style="display:none" data-l10n-id="click_badger_activate_on_site"></div>
   <div id='settings_unblock' style="display:none" data-l10n-id="settings_unblock"></div>
   <div id='settings_disable' style="display:none" data-l10n-id="settings_disable"></div>
   <div id='settings_report' style="display:none" data-l10n-id="settings_report"></div>

--- a/data/popup.js
+++ b/data/popup.js
@@ -121,8 +121,8 @@ function registerListeners(){
   var overlay = $('#overlay');
   $("#firstRun").click(function() { 
     self.port.emit("openSlideshow"); });
-  $("#badgerImg2").click(function() { self.port.emit("activateSite"); });
-  $("#badgerImg").click(function() { self.port.emit("deactivateSite"); });
+  $("#badgerImg2").click(function() { window.open("https://www.eff.org/privacybadger", "_blank"); });
+  $("#badgerImg").click(function() { window.open("https://www.eff.org/privacybadger", "_blank"); });
   $("#enableButton").click(function() { self.port.emit("activateSite"); });
   $("#disableButton").click(function() { self.port.emit("deactivateSite"); });
   $('#helpImg').click(function() { self.port.emit("openHelp"); });


### PR DESCRIPTION
When clicking on the Privacy Badger logo, it opens a new window/tab to the EFF's Privacy Badger homepage instead of activating/deactivating Privacy Badger on the site.