### PR TITLE
Display full tooltip

### DIFF
--- a/data/skin/popup.css
+++ b/data/skin/popup.css
@@ -47,7 +47,7 @@ a:hover { color: #bbbbff }
 }
 .origin{
   width: 206px;
-  color: #555555;
+  color: #555;
   font-size: 16px;
   float: left;
   display: inline;
@@ -98,7 +98,7 @@ a:hover { color: #bbbbff }
   color: #fcfcfc;
   background-color: #555;
   height: 14px;
-  border-radius: 7px;
+  border-radius: 4px;
   padding: 3px;
   z-index: 50;
   top: 0;
@@ -217,10 +217,9 @@ a:hover { color: #bbbbff }
   background: #fff;
 }
 .keyTipOuter{
-position: absolute;
-top: -25px;
-left: 100px;
-width: 230px;
+  position: absolute;
+  top: -25px;
+  left: 100px;
 }
 #blockedOriginsInner{
   margin-top: 25px;


### PR DESCRIPTION
- Remove `width` property so that tooltip can be fully displayed to the
end-user.

## Before
![original](https://cloud.githubusercontent.com/assets/844516/15878527/732cc132-2cd0-11e6-86e1-86c29753061a.png)

## After
![fixed](https://cloud.githubusercontent.com/assets/844516/15878528/76f4ebc8-2cd0-11e6-808d-dae8842fbdf2.png)
