### PR TITLE
Fixed privacy issue with repeated updates on startup

### DIFF
--- a/lib/policyCheck.js
+++ b/lib/policyCheck.js
@@ -20,13 +20,15 @@ function init() {
     storage.policyWhitelist = {};
   }
 
-  // refresh hashes on startup and every 24 hours
-  updatePrivacyPolicyHashes();
-  setInterval(updatePrivacyPolicyHashes, 1000*60*60*24);
+  // refresh hashes every 24 hours
+  setInterval(updatePrivacyPolicyHashes, 1000*60*60*48);
 
-  // Recheck heuristic-blocked sites on startup and every 24 hours.
-  recheckBlockedSites();
-  setInterval(recheckBlockedSites, 1000*60*60*24);
+  // Recheck heuristic-blocked sites every 24 hours.
+  setInterval(recheckBlockedSites, 1000*60*60*48);
+
+  //check on startup disabled for privacy reasons
+  //updatePrivacyPolicyHashes();
+  //recheckBlockedSites();
 }
 
 /**

--- a/lib/policyCheck.js
+++ b/lib/policyCheck.js
@@ -20,10 +20,10 @@ function init() {
     storage.policyWhitelist = {};
   }
 
-  // refresh hashes every 24 hours
+  // refresh hashes every 48 hours
   setInterval(updatePrivacyPolicyHashes, 1000*60*60*48);
 
-  // Recheck heuristic-blocked sites every 24 hours.
+  // Recheck heuristic-blocked sites every 48 hours.
   setInterval(recheckBlockedSites, 1000*60*60*48);
 
   //check on startup disabled for privacy reasons


### PR DESCRIPTION
Having badger start a network connection at every startup to update the lists has some privacy implications and is unneccessary. Updating every 48 hours should be more then enough.

See #816 for more info